### PR TITLE
[NICO-184] Fix percentage label positioning in the stacked bar charts

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/RoundedBarChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/RoundedBarChart.java
@@ -187,12 +187,11 @@ public class RoundedBarChart extends BarChart {
                             float barBottom = buffer.buffer[j + 3];
                             float barHeight = Math.abs(barBottom - barTop);
                             float labelY;
-                            final float MIN_LABEL_HEIGHT_PX = 12f; // threshold for label above bar
-                            if (val > 0 && barHeight < MIN_LABEL_HEIGHT_PX) {
+                            if (val < 7.0f) {
                                 // Draw label above the bar
                                 labelY = barTop - valueTextHeight;
                             } else {
-                                // Default behavior
+                                // Regular positioning
                                 labelY = val >= 0 ? (barTop + posOffset) : (barBottom + negOffset);
                             }
 
@@ -242,8 +241,8 @@ public class RoundedBarChart extends BarChart {
                             // in between
                             if (vals == null) {
 
-//                                if (!mViewPortHandler.isInBoundsRight(x)) break;
-//                                if (!mViewPortHandler.isInBoundsLeft(x)) continue;
+                               if (!mViewPortHandler.isInBoundsRight(x)) break;
+                               if (!mViewPortHandler.isInBoundsLeft(x)) continue;
 
                                 if (dataSet.isDrawValuesEnabled()) {
                                     drawValue(c, formatter.getBarLabel(entry), x, buffer.buffer[bufferIndex + 1] +
@@ -322,11 +321,11 @@ public class RoundedBarChart extends BarChart {
 
                                     float y;
 
-                                    if (Math.abs(val) < 8.0f) {
-                                        // Draw label outside (above or below) for small values
-                                        y = drawBelow ? (transformed[k + 1] + valueOffsetPlus * 2) : (transformed[k + 1] - valueOffsetPlus * 2);
+                                    if (val < 7.0f) {
+                                        // Draw label above the bar
+                                        y = buffer.buffer[bufferIndex + 1] - valueTextHeight;
                                     } else {
-                                        // Normal positioning
+                                        // Regular positioning
                                         y = transformed[k + 1] + (drawBelow ? negOffset : posOffset);
                                     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/RoundedBarChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/RoundedBarChart.java
@@ -3,6 +3,7 @@ package com.github.wuxudong.rncharts.charts;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.LinearGradient;
 import android.graphics.Path;
 import android.graphics.RectF;
@@ -319,14 +320,16 @@ public class RoundedBarChart extends BarChart {
                                         }
                                     }
 
+                                    int labelColor;
                                     float y;
-
                                     if (val < 7.0f) {
-                                        // Draw label above the bar
+                                        // Draw label above the bar with dark pink color
                                         y = buffer.buffer[bufferIndex + 1] - valueTextHeight;
+                                        labelColor = Color.parseColor("#C2185B");
                                     } else {
-                                        // Regular positioning
+                                        // Regular positioning and color
                                         y = transformed[k + 1] + (drawBelow ? negOffset : posOffset);
+                                        labelColor = dataSet.getValueTextColor(index);
                                     }
 
                                     if (!mViewPortHandler.isInBoundsRight(x))
@@ -336,7 +339,7 @@ public class RoundedBarChart extends BarChart {
                                         continue;
 
                                     if (dataSet.isDrawValuesEnabled()) {
-                                        drawValue(c, stringValue, x, y, color);
+                                        drawValue(c, stringValue, x, y, labelColor);
                                     }
 
                                     if (entry.getIcon() != null && dataSet.isDrawIconsEnabled()) {

--- a/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
+++ b/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
@@ -527,19 +527,19 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                 negOffset = (drawValueAboveBar ? valueOffsetPlus + yLabelOffset : -(valueTextHeight + valueOffsetPlus + yLabelOffset))
                             }
                         }
+                        
+                        let y: CGFloat
+
+                        if val < 8.0 {
+                            // Draw label above the bar
+                            y = rect.origin.y - valueTextHeight
+                        } else {
+                            // Regular positioning
+                            y = rect.origin.y + (val >= 0 ? posOffset : negOffset)
+                        }
 
                         if dataSet.isDrawValuesEnabled
                         {
-                            let minLabelHeight: CGFloat = 8.0
-                            let barHeight = abs(buffer[j].height)
-                            var y: CGFloat
-                            if abs(val) < minLabelHeight {
-                                // Draw label outside (above or below) for small values
-                                y = drawValueAboveBar ? (rect.origin.y + posOffset + valueOffsetPlus * 2) : (rect.origin.y + rect.size.height + negOffset - valueOffsetPlus * 2)
-                            } else {
-                                // Normal positioning
-                                y = rect.origin.y + (val >= 0 ? posOffset : negOffset)
-                            }
                             drawValue(
                                 context: context,
                                 value: stringValue,
@@ -547,7 +547,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                 yPos: y,
                                 font: valueFont,
                                 align: .center,
-                                color: dataSet.valueTextColorAt(j),
+                                color: NSUIColor.black,
                                 anchor: CGPoint(x: 0.5, y: 0.5),
                                 angleRadians: angleRadians)
                         }
@@ -642,12 +642,12 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                 let minLabelHeight: CGFloat = 8.0
                                 let barHeight = abs(buffer[bufferIndex].height)
                                 var y: CGFloat
-                                if abs(value) < minLabelHeight {
-                                    // Draw label outside (above or below) for small values
-                                    y = drawBelow ? (transformed.y + valueOffsetPlus * 2) : (transformed.y - valueOffsetPlus * 2)
+                                if value < 8.0 {
+                                    // Draw label above the bar
+                                    y = rect.origin.y - valueTextHeight
                                 } else {
-                                    // Normal positioning
-                                    y = transformed.y + (drawBelow ? negOffset : posOffset)
+                                    // Regular positioning
+                                    y = rect.origin.y + (value >= 0 ? posOffset : negOffset)
                                 }
 
                                 guard viewPortHandler.isInBoundsRight(x) else { break }
@@ -675,7 +675,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                         yPos: y,
                                         font: valueFont,
                                         align: .center,
-                                        color: dataSet.valueTextColorAt(index),
+                                        color: NSUIColor.black,
                                         anchor: CGPoint(x: 0.5, y: 0.5),
                                         angleRadians: angleRadians)
                                 }
@@ -709,7 +709,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                         (e.y >= 0 ? posOffset : negOffset),
                                     font: valueFont,
                                     align: .center,
-                                    color: dataSet.valueTextColorAt(index),
+                                    color: NSUIColor.black,
                                     anchor: CGPoint(x: 0.5, y: 0.5),
                                     angleRadians: angleRadians)
                             }

--- a/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
+++ b/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
@@ -529,13 +529,16 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                         }
                         
                         let y: CGFloat
+                        let labelColor: NSUIColor
 
                         if val < 8.0 {
-                            // Draw label above the bar
-                            y = rect.origin.y - valueTextHeight
+                            // Draw label above the bar with dark pink color
+                            y = rect.origin.y - valueTextHeight;
+                            labelColor = NSUIColor(red: 194/255.0, green: 24/255.0, blue: 91/255.0, alpha: 1.0) // #C2185B
                         } else {
-                            // Regular positioning
-                            y = rect.origin.y + (val >= 0 ? posOffset : negOffset)
+                            // Regular positioning and color
+                            y = rect.origin.y + (val >= 0 ? posOffset : negOffset);
+                            labelColor = dataSet.valueTextColorAt(j);
                         }
 
                         if dataSet.isDrawValuesEnabled
@@ -547,7 +550,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                 yPos: y,
                                 font: valueFont,
                                 align: .center,
-                                color: NSUIColor.black,
+                                color: labelColor,
                                 anchor: CGPoint(x: 0.5, y: 0.5),
                                 angleRadians: angleRadians)
                         }
@@ -642,12 +645,15 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                 let minLabelHeight: CGFloat = 8.0
                                 let barHeight = abs(buffer[bufferIndex].height)
                                 var y: CGFloat
+                                let labelColor: NSUIColor
                                 if value < 8.0 {
-                                    // Draw label above the bar
-                                    y = rect.origin.y - valueTextHeight
+                                    // Draw label above the bar with dark pink color
+                                    y = rect.origin.y - valueTextHeight;
+                                    labelColor = NSUIColor(red: 194/255.0, green: 24/255.0, blue: 91/255.0, alpha: 1.0) // #C2185B
                                 } else {
-                                    // Regular positioning
-                                    y = rect.origin.y + (value >= 0 ? posOffset : negOffset)
+                                    // Regular positioning and color
+                                    y = rect.origin.y + (value >= 0 ? posOffset : negOffset);
+                                    labelColor = value < 8.0 ? NSUIColor(red: 194/255.0, green: 24/255.0, blue: 91/255.0, alpha: 1.0) : dataSet.valueTextColorAt(index);
                                 }
 
                                 guard viewPortHandler.isInBoundsRight(x) else { break }
@@ -675,7 +681,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                         yPos: y,
                                         font: valueFont,
                                         align: .center,
-                                        color: NSUIColor.black,
+                                        color: labelColor,
                                         anchor: CGPoint(x: 0.5, y: 0.5),
                                         angleRadians: angleRadians)
                                 }
@@ -709,7 +715,7 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                                         (e.y >= 0 ? posOffset : negOffset),
                                     font: valueFont,
                                     align: .center,
-                                    color: NSUIColor.black,
+                                    color: dataSet.valueTextColorAt(index),
                                     anchor: CGPoint(x: 0.5, y: 0.5),
                                     angleRadians: angleRadians)
                             }

--- a/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
+++ b/ios/ReactNativeCharts/bar/RNRoundedBarChartRenderer.swift
@@ -530,13 +530,21 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
 
                         if dataSet.isDrawValuesEnabled
                         {
+                            let minLabelHeight: CGFloat = 8.0
+                            let barHeight = abs(buffer[j].height)
+                            var y: CGFloat
+                            if abs(val) < minLabelHeight {
+                                // Draw label outside (above or below) for small values
+                                y = drawValueAboveBar ? (rect.origin.y + posOffset + valueOffsetPlus * 2) : (rect.origin.y + rect.size.height + negOffset - valueOffsetPlus * 2)
+                            } else {
+                                // Normal positioning
+                                y = rect.origin.y + (val >= 0 ? posOffset : negOffset)
+                            }
                             drawValue(
                                 context: context,
                                 value: stringValue,
                                 xPos: x,
-                                yPos: val >= 0.0
-                                    ? (rect.origin.y + posOffset)
-                                    : (rect.origin.y + rect.size.height + negOffset),
+                                yPos: y,
                                 font: valueFont,
                                 align: .center,
                                 color: dataSet.valueTextColorAt(j),
@@ -631,7 +639,16 @@ open class RNRoundedBarChartRenderer: RNBarLineScatterCandleBubbleRenderer
                             {
                                 index = index + 1
                                 let drawBelow = (value == 0.0 && negY == 0.0 && posY > 0.0) || value < 0.0
-                                let y = transformed.y + (drawBelow ? negOffset : posOffset)
+                                let minLabelHeight: CGFloat = 8.0
+                                let barHeight = abs(buffer[bufferIndex].height)
+                                var y: CGFloat
+                                if abs(value) < minLabelHeight {
+                                    // Draw label outside (above or below) for small values
+                                    y = drawBelow ? (transformed.y + valueOffsetPlus * 2) : (transformed.y - valueOffsetPlus * 2)
+                                } else {
+                                    // Normal positioning
+                                    y = transformed.y + (drawBelow ? negOffset : posOffset)
+                                }
 
                                 guard viewPortHandler.isInBoundsRight(x) else { break }
                                 guard viewPortHandler.isInBoundsLeft(x) else { continue }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/wuxudong/react-native-charts-wrapper.git"
   },
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A react-native charts support both android and iOS.",
   "author": "wuxudong",
   "license": "MIT",


### PR DESCRIPTION
## Description
Improves how the stacked bars shows lower values like less than 8% so they're always visible

## Demo
Android
![image](https://github.com/user-attachments/assets/6db46325-2707-4988-8e52-aeddcc6fc12c)



iPhone
![image](https://github.com/user-attachments/assets/8298cae1-0947-4991-aef7-fb301173ab2f)

iPad

Landspace
![image](https://github.com/user-attachments/assets/5a8d8aa5-32b3-42a6-a795-8156b31db155)



Portrait
![image](https://github.com/user-attachments/assets/f600a242-4e01-46ad-b97b-ec921b73f580)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved value label positioning on bar charts to ensure labels for very small positive bars are always clearly visible above the bar, both for stacked and non-stacked bars.
  - Enhanced rendering of small positive bars to maintain a minimum visible height for better readability.

- **Chores**
  - Updated package version to 0.6.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->